### PR TITLE
Restore system for nodes and logs management

### DIFF
--- a/wibed-system/Makefile
+++ b/wibed-system/Makefile
@@ -43,7 +43,7 @@ define Package/wibed-system
 	+iw +mtr +ip +coreutils +coreutils-timeout +lua-curl \
 	+openssh-client +luci-lib-libremap \
 	+luci-lib-libremap-location +luci-lib-libremap-system +luci-lib-libremap-wireless \
-	+luasocket +kmod-batman-adv +batctl +uhttpd +firewall
+	+luasocket +kmod-batman-adv +batctl +uhttpd +firewall +alfred
 endef
 
 define Package/wibed-system/config

--- a/wibed-system/files/etc/hotplug.d/button/10-wbm-restore
+++ b/wibed-system/files/etc/hotplug.d/button/10-wbm-restore
@@ -2,6 +2,6 @@
 if [ "$BUTTON" = wps ] && [ "$ACTION" = released ]
 	then 
 	echo "Restoring defaults..." 
-	/sbin/firstboot -y 
+	/sbin/jffs2reset -y 
 	/sbin/reboot -f
 fi

--- a/wibed-system/files/etc/uci-defaults/wibed-config.sh
+++ b/wibed-system/files/etc/uci-defaults/wibed-config.sh
@@ -12,6 +12,12 @@ done
 
 [ ! -f /etc/config/wibed ] && cp -f /etc/wibed.default-config /etc/config/wibed
 
+# Configure ALFRED properly
+uci set 'alfred'.alfred.interface='mgmt0'
+uci set 'alfred'.alfred.disabled='0'
+uci commit
+/etc/init.d/alfred start
+
 #Fix wibed version in UCI configuration
 TEST=`tail -1 /etc/wibed.version` && uci set wibed.upgrade.version=`echo ${TEST:0:8}`
 

--- a/wibed-system/files/etc/uci-defaults/wibed-node_cronjob.sh
+++ b/wibed-system/files/etc/uci-defaults/wibed-node_cronjob.sh
@@ -8,6 +8,7 @@ if ! ( grep -q "/usr/sbin/wibed-node" /etc/crontabs/root 2>/dev/null ) ; then
 	echo "* * * * * (sleep $((30+$TIME)) ; /usr/sbin/wibed-node >> /tmp/wibed-node.log)" >> /etc/crontabs/root
 	echo "* * * * * (sleep $((45+$TIME)) ; /usr/sbin/wibed-node >> /tmp/wibed-node.log)" >> /etc/crontabs/root
 	echo "* * * * * (sleep $((5+$TIME)) ; /usr/sbin/wibed-status > /root/wibed-status.log)" >> /etc/crontabs/root
+	echo "0 0 * * * /usr/sbin/wibed-rmlogs" >> /etc/crontabs/root
 	/etc/init.d/cron enable
 	/etc/init.d/cron restart
 fi

--- a/wibed-system/files/etc/uci-defaults/wibed-restore_cronjob.sh
+++ b/wibed-system/files/etc/uci-defaults/wibed-restore_cronjob.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+	
+if ! ( grep -q "/usr/sbin/wibed-restore" /etc/crontabs/root 2>/dev/null ) ; then
+	SEED="$( dd if=/dev/urandom bs=2 count=1 2>&- | hexdump | if read line; then echo 0x${line#* }; fi )"
+	TIME="$(( $SEED % 15 ))"
+	echo "* * * * * (sleep $((0+$TIME)) ; /usr/sbin/wibed-restore node >> /root/wibed-restore.log)" >> /etc/crontabs/root
+	echo "* * * * * (sleep $((15+$TIME)) ; /usr/sbin/wibed-restore node >> /root/wibed-restore.log)" >> /etc/crontabs/root
+	echo "* * * * * (sleep $((30+$TIME)) ; /usr/sbin/wibed-restore node >> /root/wibed-restore.log)" >> /etc/crontabs/root
+	echo "* * * * * (sleep $((45+$TIME)) ; /usr/sbin/wibed-restore node >> /root/wibed-restore.log)" >> /etc/crontabs/root
+	/etc/init.d/cron enable
+	/etc/init.d/cron restart
+fi

--- a/wibed-system/files/usr/sbin/ssh-all
+++ b/wibed-system/files/usr/sbin/ssh-all
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+[ -z "$2" ] && {
+    echo "This script executes commands and copy files to all nodes"
+    echo "connected to a network interface (link-local connection)."
+    echo "It uses IPv6 to discover the IPv6 link local addresses" 
+	echo ""
+	echo "$0 <interface> <-c|-cb|-f> [parameters]"
+	echo "  -c  -> execute command"
+	echo "  -cb -> execute command in background"
+    echo "  -f  -> copy file"
+    exit 0
+} 
+
+I="$1"
+shift
+T="$1"
+shift
+
+TMP="/tmp/wibed"
+
+echo "Discovering nodes..."
+ping6 ff02::2%$I -c 5 -i 1 -s 16 | grep "^24" > $TMP.nodes.tmp
+cat $TMP.nodes.tmp  | awk '{print $4}' | sed s/":$"//g | sort -u > $TMP.nodes
+echo "-------------------------"
+cat $TMP.nodes
+echo "-------------------------"
+
+echo
+
+[ "$T" == "-c" ] && {
+C="$@"
+echo "Executing command $C"
+for IP in $(cat $TMP.nodes)
+	do
+	echo "-------------------------"
+	echo "  $IP"
+	echo "-------------------------"
+	ssh -t $IP%$I $@
+	done
+}
+
+[ "$T" == "-cb" ] && {
+C="$@"
+echo "Executing background command $C"
+for IP in $(cat $TMP.nodes)
+	do
+	echo "-------------------------"
+	echo "  $IP"
+	echo "-------------------------"
+	ssh -ft $IP%$I $@
+	done
+}
+[ "$T" == "-f" ] && {
+O="$1"
+D="$2"
+echo "Copying file $O into $D"
+for IP in $(cat $TMP.nodes)
+	do
+	scp -r $O [$IP%$I]:$D
+	done
+}
+

--- a/wibed-system/files/usr/sbin/ssh-all
+++ b/wibed-system/files/usr/sbin/ssh-all
@@ -19,9 +19,12 @@ shift
 
 TMP="/tmp/wibed"
 
+INT=${INT:-mgmt0}
+MYLOCALLINK="$(ip addr show dev $INT | grep -e "inet6.*scope link" | awk '{print $2}' | cut -d/ -f1)"
+
 echo "Discovering nodes..."
 ping6 ff02::2%$I -c 5 -i 1 -s 16 | grep "^24" > $TMP.nodes.tmp
-cat $TMP.nodes.tmp  | awk '{print $4}' | sed s/":$"//g | sort -u > $TMP.nodes
+cat $TMP.nodes.tmp  | awk '{print $4}' | sed s/":$"//g | grep -v "${MYLOCALLINK}" | sort -u > $TMP.nodes
 echo "-------------------------"
 cat $TMP.nodes
 echo "-------------------------"

--- a/wibed-system/files/usr/sbin/wibed-node
+++ b/wibed-system/files/usr/sbin/wibed-node
@@ -639,6 +639,15 @@ function sendRestore(nodeid, reset)
         end
 end
 
+-- Acquire the lock before proceeding any further
+-- Guarantees only one script execution at a time
+os.execute(string.format("lock -w /tmp/wibed-node-lock; lock /tmp/wibed-node-lock"))
+
+print("---------------------------------------")
+_, date = executeCommand(string.format("date"))
+print(date)
+print("---------------------------------------")
+
 apiUrl = assert(readVariable("general.api_url"), "API URL not defined")
 print(string.format("API URL: %s", apiUrl))
 id = assert(readVariable("general.node_id"), "Node ID not defined")
@@ -825,3 +834,8 @@ if responseBody and statusCode == 200 then
 else
     print(string.format("Communication with server unsuccessful: %s", statusCode))
 end
+
+-- Release the lock
+--
+os.execute(string.format("lock -u /tmp/wibed-node-lock"))
+

--- a/wibed-system/files/usr/sbin/wibed-node
+++ b/wibed-system/files/usr/sbin/wibed-node
@@ -8,6 +8,11 @@ json = require ("dkjson")
 libuci = require ("uci")
 cURL = require("cURL")
 
+-- Controls the timeout for http.request to the server
+--
+socket.http.TIMEOUT = 10
+
+
 RESULTS_DIR = "/root/results"
 COMMANDS_PIPE = "/var/run/command-executer.sock"
 OVERLAY_DIR = "/overlay"

--- a/wibed-system/files/usr/sbin/wibed-node
+++ b/wibed-system/files/usr/sbin/wibed-node
@@ -612,12 +612,31 @@ end
 
 -- Function: getMgmtAddress()
 --
--- return's node's MAC address for mgmg0 interface
+-- returns node's MAC address for mgmt0 interface
 --
 
 function getMgmtAddress()
 	local _, mymac = executeCommand(string.format("cat /sys/class/net/mgmt0/address"))
 	return mymac
+end
+
+-- Function: sendRestore
+-- 
+-- Sends restore command to the specified nodeid through alfred
+-- may be a simple reboot or reset with commands preexecution (if in experiment)
+-- Parameters: nodeid (id of the node to restore); reset (signal to reexecute previous commands)
+
+function sendRestore(nodeid, reset)
+        if nodeid ~=nil then
+                executeCommand(string.format("uci set wibed.temp=wibed; uci set wibed.temp.gwack='1'; uci commit"))
+                if reset == true then
+                        executeCommand(string.format("/usr/sbin/wibed-restore gw %s full", nodeid))
+                elseif reset == false then
+                        executeCommand(string.format("/usr/sbin/wibed-restore gw %s", nodeid))
+                else
+                        print(string.format("Invalid reset argument. Expecting True or False. Got something diferent"))
+                end
+        end
 end
 
 apiUrl = assert(readVariable("general.api_url"), "API URL not defined")
@@ -676,6 +695,20 @@ elseif status == IDLE or status == RUNNING or status == ERROR then
         request["results"] = buildResults()
         request["commandAck"] = commandAck
     end
+    
+    -- Sending gateway & node ACK to the server (for sendRestore process)
+    --
+    local _, gwack = executeCommand(string.format("uci get wibed.temp.gwack -q"))
+    local _, nodeack = executeCommand(string.format("uci get wibed.temp.nodeack -q"))
+    if gwack == "1" then
+       request["sendRestore"] = "GWACK"
+       executeCommand(string.format("uci set wibed.temp.gwack='0'; uci commit"))
+    end
+    if nodeack == "1" then
+       request["sendRestore"] = "NODEACK"
+       executeCommand(string.format("uci set wibed.temp.nodeack='0'; uci commit"))
+    end
+
 end
 
 jsonEncodedRequest = json.encode(request, {indent = true})
@@ -751,6 +784,14 @@ if responseBody and statusCode == 200 then
                                 experiment["overlay"],
                                 experiment["hash"])
         end
+
+        -- Processing request to restore the specified node
+        --
+        local sendrestore = response["sendRestore"]
+        if sendrestore then
+            sendRestore(sendrestore["dest"],sendrestore["reset"])
+        end
+
     elseif response["experiment"] and status >= PREPARING 
                                   and status <= RUNNING then
         if response["experiment"]["action"] == "FINISH" then

--- a/wibed-system/files/usr/sbin/wibed-restore
+++ b/wibed-system/files/usr/sbin/wibed-restore
@@ -96,6 +96,9 @@ function restoreCheck()
         if msg~=nil then
                 restore, _, reset, _ = alfMsgFind(msg, nodeid)
                         if restore == "RESTORE" then
+				os.execute(string.format("echo '---------------------------------------'"))
+				os.execute(string.format("echo $(date)"))
+				os.execute(string.format("echo '---------------------------------------'"))
                                 if reset == "RESET" then
 					os.execute(string.format("echo 'Recieved RESTORE command'"))
                                         -- Send ACK to the GW

--- a/wibed-system/files/usr/sbin/wibed-restore
+++ b/wibed-system/files/usr/sbin/wibed-restore
@@ -1,0 +1,155 @@
+#!/usr/bin/lua
+
+-- Script allows to reboot any other node remotely from the nearest GW node,
+-- using ALFRED message exchange.
+-- It may be a simple reboot or reset with commands reexecution (if in experiment)
+--
+
+-- Lua doesn't have sleep function. SRSLY?
+function sleep(n)
+        os.execute("sleep " .. tonumber(n))
+end
+
+-- Get our nodeid
+function myNodeId()
+	local idhandle = io.popen("uci get wibed.general.node_id")
+	local nodeid  = idhandle:read("*a")
+	idhandle:close()
+	nodeid = string.gsub(nodeid, "%s+$", "" )
+	return nodeid
+end
+
+--Checks the given message for a line with nodeid and if found returns the values of this line
+--
+function alfMsgFind(msg, nodeid)
+        if msg~=nil then -- ignore empty messages
+                for line in msg:gmatch("[^\r\n]+") do -- split msg into lines
+                        line = string.gsub(line, ':', "") -- remove : from sender's MAC
+                        local twords = {}
+                        for word in string.gmatch(line, "%w+") do -- find all words
+                                table.insert (twords, word)
+                        end
+			if twords[2]=="RESTORE" then
+                        	if twords[3]..'-'..twords[4]==nodeid then -- tweak for wibed-xxxx nodeid format
+        	                        return twords[2], twords[3]..'-'..twords[4], twords[5], twords[6]
+                        	end
+			end
+                end
+        end
+end
+
+function sendRestore(nodeid, full) -- Sends restore command to specified node
+        if nodeid == nil then
+                print(string.format("No nodeid specified"))
+        else
+                if full == nil then
+			print("Sending RESTORE command to node: "..nodeid)
+        	        os.execute(string.format("echo 'RESTORE %s NONE NONE' | alfred -s 92", nodeid))
+		else
+			print ("Sending RESTORE with RESET command to node: "..nodeid)
+	                os.execute(string.format("echo 'RESTORE %s RESET NONE' | alfred -s 92", nodeid))
+		end
+
+                -- Check for ACK from the node
+                local n=0
+                while n~=1 do
+                        local msg = alfMsgCheck(93)
+                        if msg~=nil then
+                                _, _, _, ack = alfMsgFind(msg, nodeid)
+                                if ack=="ACK" then
+                                        print ("ACK recieved. Erasing the restore Alfred message")
+                                        os.execute(string.format("echo 'NONE NONE NONE NONE' | alfred -s 92"))
+					os.execute(string.format("uci set wibed.temp.nodeack='1'; uci commit"))
+					n=n+1
+                                else
+                                        print ("No ACK yet")
+                                        sleep(10)
+                                end
+                        end
+                end
+
+
+        end
+end
+
+-- Retrieves alfred messages of the specified ID
+--
+function alfMsgCheck(id)
+        if id==92 or 93 then
+                local msghandle = io.popen("alfred -r "..id)
+                local msg = msghandle:read("*a")
+                msghandle:close()
+		if msg then
+			msg = string.gsub( msg, "%s+$", "" ) -- remove any white space at the end
+		end
+                return msg
+        else
+                print ("ID is not known. 92 for RESTORE. 93 for ACK")
+        end
+end
+
+-- Checks if there are commands for a node to be restored
+function restoreCheck()
+        local msg = alfMsgCheck(92)
+	local nodeid = myNodeId()
+
+        if msg~=nil then
+                restore, _, reset, _ = alfMsgFind(msg, nodeid)
+                        if restore == "RESTORE" then
+                                if reset == "RESET" then
+					os.execute(string.format("echo 'Recieved RESTORE command'"))
+                                        -- Send ACK to the GW
+					os.execute(string.format("echo 'Sending ACK to the GW'"))
+                                        os.execute(string.format("echo 'RESTORE %s RESET ACK' | alfred -s 93", nodeid))
+					sleep(10)
+					-- Erase the ACK
+					os.execute(string.format("echo 'Erasing ACK'"))
+					os.execute(string.format("echo 'NONE NONE NONE NONE' | alfred -s 93"))
+					sleep(10)
+					-- Reboot the node with reset
+					os.execute(string.format("echo 'Resetting the node with commands reexecution ...'"))
+					sleep(2)
+					os.execute(string.format("/sbin/jffs2reset -y; reboot -f"))
+                                else
+					os.execute(string.format("echo 'Recieved RESET command'"))
+                                        -- Send ACK for reset
+					os.execute(string.format("echo 'Sending ACK to the GW'"))
+                                        os.execute(string.format("echo 'RESTORE %s NONE ACK' | alfred -s 93", nodeid))
+					sleep(10)
+					-- Erase the ACK
+					os.execute(string.format("echo 'Erasing ACK'"))
+					os.execute(string.format("echo 'NONE NONE NONE NONE' | alfred -s 93"))
+					sleep(10)
+                                        -- reboot the node
+					os.execute(string.format("echo 'Rebooting the node and continue with the last command ...'"))
+					sleep(2)
+                                        os.execute(string.format("reboot -f"))
+                                end
+                        end
+
+        end
+end
+
+-- call it with the following arguments
+-- lua wibed-restore gw nodeid full/nill  -- for gateway to send restore command to specific node
+-- OR
+-- lua wibed-restore node 	-- for a node to start checking for restore messages
+
+function main()
+	if arg[1]=="gw" then
+		if arg[2] ~=nil then
+			sendRestore(arg[2], arg[3])
+		else
+			print ("Wrong arguments. Should be gw nodeid full/nill")
+		end
+	elseif arg[1]=="node" then
+		restoreCheck()
+	else
+		print ("Wrong arguments. Should be gw/node nodeid/nill full/nill")
+	end
+end
+
+os.execute(string.format("lock -w /tmp/wibed-restore-lock; lock /tmp/wibed-restore-lock"))
+main()
+os.execute(string.format("lock -u /tmp/wibed-restore-lock"))
+

--- a/wibed-system/files/usr/sbin/wibed-rmlogs
+++ b/wibed-system/files/usr/sbin/wibed-rmlogs
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+
+file1=/tmp/wibed-node.log
+file2=/root/wibed-restore.log
+
+maxsize1=1024	# 1024 kilobytes
+maxsize2=50	# 50 kilobytes
+
+actualsize1=$(du -k "$file1" | cut -f1)
+actualsize2=$(du -k "$file2" | cut -f1)
+
+if [ $actualsize1 -ge $maxsize1 ]; then
+        lock -w /tmp/wibed-node-lock; lock /tmp/wibed-node-lock
+        mv $file1 $file1.old
+        lock -u /tmp/wibed-node-lock
+fi
+
+
+if [ $actualsize2 -ge $maxsize2 ]; then
+        lock -w /tmp/wibed-restore-lock; lock /tmp/wibed-restore-lock
+        mv $file2 $file2.old
+        lock -u /tmp/wibed-restore-lock
+fi
+


### PR DESCRIPTION
Restore system for nodes. This feature concerns nodes that are still connected in the mgmt networks but have somehow lost connectivity to the server.

Automatic logs management: deletes wibed-node and wibed-restore logs when they reach a specified size. 

ssh-all script is now available by default. Now it doesn't send to itself while distributing a file. 
