### PR TITLE
Removed locks from wibed-node script

### DIFF
--- a/wibed-system/files/usr/sbin/wibed-node
+++ b/wibed-system/files/usr/sbin/wibed-node
@@ -649,7 +649,7 @@ end
 
 -- Acquire the lock before proceeding any further
 -- Guarantees only one script execution at a time
-os.execute(string.format("lock -w /tmp/wibed-node-lock; lock /tmp/wibed-node-lock"))
+-- os.execute(string.format("lock -w /tmp/wibed-node-lock; lock /tmp/wibed-node-lock"))
 
 print("---------------------------------------")
 _, date = executeCommand(string.format("date"))
@@ -845,5 +845,5 @@ end
 
 -- Release the lock
 --
-os.execute(string.format("lock -u /tmp/wibed-node-lock"))
+--os.execute(string.format("lock -u /tmp/wibed-node-lock"))
 


### PR DESCRIPTION
Commented out lines with locks for remote restore/reboot functionality. Having these lines may cause a deadlock
