### PR TITLE
Added wifi config to reset_wifi function

### DIFF
--- a/wibed-system/files/usr/sbin/wibed-config
+++ b/wibed-system/files/usr/sbin/wibed-config
@@ -143,6 +143,7 @@ local function reset_wifi()
 	os.execute("cp -f /etc/config/wireless /tmp/wireless.backup")
 	os.execute('echo "" > /etc/config/wireless')
 	os.execute('wifi detect > /etc/config/wireless')
+    os.execute('wifi config')
 end
 
 local function wifi_up()


### PR DESCRIPTION
"wifi detect" does nothing since commit 5f8f8a366136a07df661e31decce2458357c167aon LEDE.

Since wibed config configures unconfigured wireless devices, I just
added a wifi config execution after wifi detect. If wifi detect does not work ( because it's a
newer version ), wifi config will do the work. This way we can keep
compatiblity with older versions, like stable versions of OpenWRT or
older revisions of LEDE.